### PR TITLE
Added extra check for skin items to be separated

### DIFF
--- a/app/code/community/Lesti/Merge/Core/Model/Layout/Update.php
+++ b/app/code/community/Lesti/Merge/Core/Model/Layout/Update.php
@@ -40,6 +40,9 @@ class Lesti_Merge_Core_Model_Layout_Update extends Mage_Core_Model_Layout_Update
                 foreach($xml->children() as $handle => $child){
                     $items = $child->xpath(".//action[@method='".$method."']");
                     foreach($items as $item) {
+                        if ($method == 'addItem' && ((!$shouldMergeCss && (string)$item->{'type'} == 'skin_css') || (!$shouldMergeJs && (string)$item->{'type'} == 'skin_js'))){
+                            continue;
+                        }
                         $params = $item->xpath("params");
                         if(count($params)) {
                             foreach($params as $param){


### PR DESCRIPTION
Normally when $shouldMergeCss is false but there are skin_css items it would still split them up by its handle.
This fix prevents that from happening for skin_css and skin_js.
