### PR TITLE
JS files reordering skin_js before js when mergecss enabled but merge…

### DIFF
--- a/app/code/community/Lesti/Merge/Core/Model/Layout/Update.php
+++ b/app/code/community/Lesti/Merge/Core/Model/Layout/Update.php
@@ -41,7 +41,7 @@ class Lesti_Merge_Core_Model_Layout_Update extends Mage_Core_Model_Layout_Update
                 foreach($xml->children() as $handle => $child){
                     $items = $child->xpath(".//action[@method='".$method."']");
                     foreach($items as $item) {
-                        if ($method == 'addItem' && ((!$shouldMergeCss && (string)$item->{'type'} == 'skin_css') || (!$shouldMergeJs && (string)$item->{'type'} == 'skin_js'))){
+                        if ($method == 'addItem' && ((!$shouldMergeCss && (string)$item->{'type'} == 'skin_css') || (!$shouldMergeJs && ((string)$item->{'type'} == 'skin_js' || (string)$item->{'type'} == 'js')))){
                             continue;
                         }
                         $params = $item->xpath("params");


### PR DESCRIPTION
If mergecss is enabled and mergejs is disabled, any js inserted with `<action method="addItem"><type>js</type>` appear after those with `<action method="addItem"><type>skin_js</type>`. This is the opposite of what Magento does by default and causes issues with loading in js in the correct order.
